### PR TITLE
fixes #47, sends null if global parameter computation fails

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.pythonPath": "C:\\Python27\\ArcGISx6410.7\\python.exe"
+}


### PR DESCRIPTION
- replicated the AttributesFromWorkspace.py to get parameters from the watershed's attribute table instead of reading the parameter.xml
- when the watershed is global and a global parameter fails, send back null rather than the local value